### PR TITLE
fix(windows): provide the required Common Controls v6 manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,7 +237,7 @@ jobs:
           name: nuget-packages
           path: artifacts/packages
 
-      - name: Restore and build clean Windows consumer
+      - name: Restore, build, and run clean Windows consumer
         shell: pwsh
         run: |
           [xml] $props = Get-Content Directory.Build.props
@@ -272,9 +272,52 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet restore $smokeProject --configfile $nugetConfig --packages $packagesPath --runtime $rid
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          # Windows application manifests are consumer-owned; this job validates restore and build only.
           dotnet build $smokeProject --runtime $rid --no-restore
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          dotnet run `
+              --project $smokeProject `
+              --runtime $rid `
+              --no-build `
+              --no-restore
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Run Windows file-based consumer
+        shell: pwsh
+        run: |
+          [xml] $props = Get-Content Directory.Build.props
+          $version = [string] $props.Project.PropertyGroup.Version
+          $fileSmoke = 'artifacts/file-smoke'
+          if (Test-Path $fileSmoke) { Remove-Item $fileSmoke -Recurse -Force }
+          New-Item -ItemType Directory -Path $fileSmoke | Out-Null
+          $packageSource = (Resolve-Path -LiteralPath 'artifacts/packages').Path
+          $nugetSource = 'https://api.nuget.org/v3/index.json'
+          @"
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <clear />
+              <add key="local" value="$packageSource" />
+              <add key="nuget.org" value="$nugetSource" />
+            </packageSources>
+          </configuration>
+          "@ | Set-Content -LiteralPath "$fileSmoke/NuGet.Config" -Encoding utf8
+          @"
+          #:property TargetFramework=net10.0
+          #:property RuntimeIdentifier=win-x64
+          #:package GPUI.NET@$version
+
+          using Gpui.Interop;
+
+          var runtime = NativeRuntime.Load();
+          Console.WriteLine("Loaded " + runtime.GetType().FullName + " from file-based GPUI.NET app.");
+          "@ | Set-Content -LiteralPath "$fileSmoke/app.cs" -Encoding utf8
+          Push-Location $fileSmoke
+          try {
+            dotnet run --file app.cs
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          } finally {
+            Pop-Location
+          }
 
   macos-consumer:
     name: Validate ${{ matrix.rid }} NuGet consumer

--- a/NUGET_README.md
+++ b/NUGET_README.md
@@ -43,10 +43,13 @@ internal sealed partial class MainView : View
 
 - .NET SDK/runtime 10.
 - A desktop environment supported by the selected runtime identifier.
-- On Windows, the application executable must embed a Common Controls v6 application manifest.
+- On Windows, `GPUI.NET` supplies a default Windows application manifest for executable projects.
 
-The Windows manifest is owned by the consuming application. A reference manifest is available in
-the [sample application](https://github.com/akeit0/gpui-dotnet/tree/main/samples/Gpui.Sample).
+The default manifest enables Common Controls v6 and Per-Monitor V2 DPI awareness. An explicitly
+configured consumer `ApplicationManifest` is preserved, and `NoWin32Manifest=true` disables the
+package-provided manifest. A custom manifest must include `Microsoft.Windows.Common-Controls`
+version `6.0.0.0`; without it, Windows may fail to load the native host because the
+common-control API set is not activated for the process.
 
 ## Links
 

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -108,7 +108,7 @@ unless a separate label automation is added.
 
 The `Release` GitHub Actions workflow builds and tests all four native RIDs on their platform
 runners, assembles the package family, and verifies clean local restores and runtime loading on
-Linux and macOS plus a Windows restore/build consumer check. The package version comes from
+Linux, macOS, and Windows, including a file-based `#:package` consumer on Windows. The package version comes from
 `Directory.Build.props`; a release tag must match that version, with an optional leading `v`.
 
 Configure a NuGet.org trusted publishing policy with:
@@ -138,10 +138,34 @@ A release pipeline should verify:
 - NativeAOT publishing succeeds for supported RIDs;
 - no package attempts to compile Rust on the consumer machine.
 
-Windows consumers must also embed a Common Controls v6 application manifest in the executable;
-the sample's `app.manifest` is the reference. Without it, Windows may fail to load the native host
-because the common-control API set is not activated for the process. The release workflow therefore
-keeps its Windows package check at restore/build; the application manifest remains consumer-owned.
+## Windows application manifest
+
+`GPUI.NET` ships a default Windows application manifest through `buildTransitive`:
+
+```text
+buildTransitive/GPUI.NET.targets
+buildTransitive/GPUI.NET.Windows.manifest
+```
+
+The target applies only to Windows executable projects (`Exe`/`WinExe`). When the consumer has
+not already set `ApplicationManifest` and has not set `NoWin32Manifest=true`, the package sets
+`ApplicationManifest` to its bundled `GPUI.NET.Windows.manifest`. The default enables Common
+Controls v6 (`Microsoft.Windows.Common-Controls` version `6.0.0.0`) and Per-Monitor V2 DPI
+awareness.
+
+Custom-manifest ownership is preserved: an explicitly configured consumer `ApplicationManifest`
+is never overwritten, and `NoWin32Manifest=true` opts out of the package-provided manifest. A
+custom manifest must include `Microsoft.Windows.Common-Controls` version `6.0.0.0`; without it,
+Windows may fail to load the native host because the common-control API set is not activated
+for the process. The sample keeps its explicit `app.manifest` because it consumes `Gpui.csproj`
+through `ProjectReference`, which does not apply NuGet `buildTransitive` assets.
+
+Windows clean-consumer validation restores a `net10.0` / `win-x64` project with no
+`ApplicationManifest` from the packed `GPUI.NET` package, verifies the MSBuild
+`ApplicationManifest` property points at the package-provided manifest, then builds and runs the
+consumer so `NativeRuntime.Load()` proves the Common Controls v6 dependency resolves. A second
+file-based `#:package GPUI.NET@<version>` consumer (`dotnet run --file app.cs`) covers the
+file-based reproduction path.
 
 ## Extensions
 

--- a/eng/pack.ps1
+++ b/eng/pack.ps1
@@ -74,4 +74,22 @@ foreach ($entry in $nativeEntries.GetEnumerator()) {
     }
 }
 
+$gpuiPackagePath = Join-Path $packOutput "GPUI.NET.$version.nupkg"
+$gpuiBuildEntries = @(
+    'buildTransitive/GPUI.NET.targets',
+    'buildTransitive/GPUI.NET.Windows.manifest'
+)
+
+$archive = [System.IO.Compression.ZipFile]::OpenRead($gpuiPackagePath)
+try {
+    foreach ($entry in $gpuiBuildEntries) {
+        if ($null -eq $archive.GetEntry($entry)) {
+            throw "GPUI.NET does not contain $entry."
+        }
+    }
+}
+finally {
+    $archive.Dispose()
+}
+
 Write-Host "Packed GPUI.NET $version ($($actualFiles.Count) packages) into $packOutput"

--- a/src/Gpui/Gpui.csproj
+++ b/src/Gpui/Gpui.csproj
@@ -29,6 +29,16 @@
         <None Include="$(RepositoryRoot)/NOTICE" Pack="true" PackagePath="\" />
         <None Include="$(RepositoryRoot)/docs/EXTENSIONS.md" Pack="true" PackagePath="docs" />
         <None
+            Include="buildTransitive/GPUI.NET.targets"
+            Pack="true"
+            PackagePath="buildTransitive/GPUI.NET.targets"
+        />
+        <None
+            Include="buildTransitive/GPUI.NET.Windows.manifest"
+            Pack="true"
+            PackagePath="buildTransitive/GPUI.NET.Windows.manifest"
+        />
+        <None
             Include="$(RepositoryRoot)/src/Gpui.Generators/bin/$(Configuration)/netstandard2.0/Gpui.Generators.dll"
             Pack="true"
             PackagePath="analyzers/dotnet/cs"

--- a/src/Gpui/buildTransitive/GPUI.NET.Windows.manifest
+++ b/src/Gpui/buildTransitive/GPUI.NET.Windows.manifest
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity
+    type="win32"
+    version="1.0.0.0"
+    name="GPUI.NET.Application" />
+
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*" />
+    </dependentAssembly>
+  </dependency>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/Gpui/buildTransitive/GPUI.NET.targets
+++ b/src/Gpui/buildTransitive/GPUI.NET.targets
@@ -1,0 +1,18 @@
+<Project>
+    <PropertyGroup>
+        <_GpuiIsWindowsTarget
+            Condition="
+                '$(TargetPlatformIdentifier)' == 'Windows'
+                or $([MSBuild]::IsOSPlatform('Windows'))
+                or $([System.String]::Copy('$(RuntimeIdentifier)').StartsWith('win-'))">true</_GpuiIsWindowsTarget>
+    </PropertyGroup>
+
+    <PropertyGroup
+        Condition="
+            '$(_GpuiIsWindowsTarget)' == 'true'
+            and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe')
+            and '$(ApplicationManifest)' == ''
+            and '$(NoWin32Manifest)' != 'true'">
+        <ApplicationManifest>$(MSBuildThisFileDirectory)GPUI.NET.Windows.manifest</ApplicationManifest>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary

- ship a default Windows application manifest from `GPUI.NET` via `buildTransitive`
- enable Common Controls v6 for consumers that do not provide their own manifest
- preserve explicitly configured `ApplicationManifest` and `NoWin32Manifest`
- run Windows NuGet consumers instead of validating build only
- add coverage for the .NET 10 file-based `#:package` consumer
- update package and packaging documentation

## Local validation

- packed `src/Gpui/Gpui.csproj` locally with `BuildGpuiNative=false`
- verified the `.nupkg` contains both `buildTransitive` assets
- restored a clean `net10.0` / `win-x64` consumer from the local package
- verified the package-provided `ApplicationManifest` MSBuild property
- successfully ran the clean consumer and loaded the native runtime
- verified an explicit custom manifest is not overwritten
- verified `NoWin32Manifest=true` is respected
- successfully ran a file-based .NET 10 consumer using `#:package GPUI.NET@<version>`
- ran applicable repository validation commands (`bindings verify`, `dotnet test`, sample build, `cargo fmt --check`, `cargo test`)

Notes:

- `GPUI.NET.targets` keeps the `true` value inline (`>true</`): a multiline element value carries whitespace and breaks the `== 'true'` comparison (verified locally — the property stayed empty otherwise).
- Full `eng/pack.ps1` was not run locally (only the `win-x64` native asset is staged here); the cross-RID package-family gate is left to CI.
- `mt.exe` manifest inspection skipped (unavailable); the runtime load test passed and is authoritative.

Closes #2
