### PR TITLE
chore: bump to 0.2.0-preview.1 and centralize versioning

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/version-bump.md
+++ b/.github/PULL_REQUEST_TEMPLATE/version-bump.md
@@ -1,0 +1,25 @@
+# Version bump to `<version>`
+
+> Replace `<version>` with the new version.
+> See [Versioning](../../docs/PACKAGING.md#versioning).
+
+## Checklist
+
+- [ ] Bumped with `./eng/bump-version.sh <version>` (`./eng/bump-version.ps1 -Version <version>` on Windows).
+- [ ] `./eng/check-version.sh` passes.
+- [ ] `dotnet run --project tools/Gpui.Bindings.Generator -- verify` passes.
+- [ ] `cargo test --manifest-path crates/gpui-dotnet/Cargo.toml` passes.
+- [ ] `dotnet test Gpui.slnx --no-restore` passes.
+- [ ] No version literals added outside `Directory.Build.props`, the Cargo workspace
+      version, and generated `Cargo.lock` (`README.md` and tag/doc examples stay
+      version-agnostic).
+
+## After merge
+
+Tag the release commit (the `Release` workflow requires the tag on `main`):
+
+```sh
+version=$(sed -n 's/.*<Version>\([^<]*\)<\/Version>.*/\1/p' Directory.Build.props)
+git tag "v$version"
+git push origin "v$version"
+```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,10 @@ jobs:
               throw "Release tag '$($env:RELEASE_TAG)' must match package version '$version' (optional leading 'v')."
           }
 
+      - name: Verify version consistency
+        shell: pwsh
+        run: ./eng/check-version.ps1
+
       - name: Install Linux runtime dependencies
         run: |
           sudo apt-get update

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Deterministic>true</Deterministic>
-        <Version>0.1.0-preview.1</Version>
+        <Version>0.2.0-preview.1</Version>
         <Authors>Akito Inoue</Authors>
         <Copyright>Copyright (c) 2026 Akito Inoue</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ materializes GPUI elements, windows, controls, and retained resources.
 The API is semantic rather than a direct binding of every GPUI Rust type. This keeps normal C#
 code platform-neutral and lets the native implementation evolve behind a versioned C ABI.
 
-The current package line is `0.1.0-preview.1`. It is a first preview: public APIs, the semantic
+This is a preview release: public APIs, the semantic
 schema, and the native ABI may change before a stable release.
 
 ## Features at a glance
@@ -96,8 +96,10 @@ managed output.
 ## Install from NuGet
 
 ```sh
-dotnet add package GPUI.NET --version 0.1.0-preview.1
+dotnet add package GPUI.NET
 ```
+
+Pin a specific preview with `dotnet add package GPUI.NET --version <version>`.
 
 The `GPUI.NET` package brings the managed API and the platform-specific native package family.
 Package consumers need the .NET 10 SDK/runtime and a desktop environment supported by the selected

--- a/crates/gpui-dotnet/Cargo.lock
+++ b/crates/gpui-dotnet/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "gpui-dotnet"
-version = "0.1.0-preview.1"
+version = "0.2.0-preview.1"
 dependencies = [
  "async-channel",
  "csbindgen",
@@ -2479,14 +2479,14 @@ dependencies = [
 
 [[package]]
 name = "gpui-dotnet-default-host"
-version = "0.1.0-preview.1"
+version = "0.2.0-preview.1"
 dependencies = [
  "gpui-dotnet",
 ]
 
 [[package]]
 name = "gpui-dotnet-editor-host"
-version = "0.1.0-preview.1"
+version = "0.2.0-preview.1"
 dependencies = [
  "gpui",
  "gpui-component",

--- a/crates/gpui-dotnet/Cargo.toml
+++ b/crates/gpui-dotnet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpui-dotnet"
-version = "0.1.0-preview.1"
+version.workspace = true
 edition = "2024"
 publish = false
 
@@ -9,6 +9,8 @@ members = ["hosts/default", "extensions/editor-host"]
 default-members = [".", "hosts/default"]
 resolver = "3"
 
+[workspace.package]
+version = "0.2.0-preview.1"
 # Deny the lint groups that silently change behavior when missed: an unresolved
 # constant in pattern position becomes a catch-all binding, and dead code hides
 # untested paths. Scoped to groups rather than `warnings` so toolchain upgrades

--- a/crates/gpui-dotnet/extensions/editor-host/Cargo.toml
+++ b/crates/gpui-dotnet/extensions/editor-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpui-dotnet-editor-host"
-version = "0.1.0-preview.1"
+version.workspace = true
 edition = "2024"
 publish = false
 

--- a/crates/gpui-dotnet/hosts/default/Cargo.toml
+++ b/crates/gpui-dotnet/hosts/default/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpui-dotnet-default-host"
-version = "0.1.0-preview.1"
+version.workspace = true
 edition = "2024"
 publish = false
 

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -85,15 +85,49 @@ application meta package, verifies the native entries, and writes packages to
 Every package embeds the standalone repository-root `NUGET_README.md` as its NuGet readme. The
 repository `README.md` remains the project overview and is not copied into packages.
 
-## NuGet release
+## Versioning
 
-The `Release` workflow runs when a version tag is pushed. Create a tag matching the version in
-`Directory.Build.props` and push it, for example:
+`Directory.Build.props` (`/Project/PropertyGroup/Version`) is the single source of truth for the
+package version. All NuGet projects inherit it through MSBuild, and `eng/pack.ps1` plus the
+`Release` workflow read it back to name and verify the `.nupkg` files.
+
+Rust crates are not published, so their versions exist only to keep diagnostics consistent. They
+share one Cargo workspace version instead of repeating it per crate:
+
+- `crates/gpui-dotnet/Cargo.toml` defines `[workspace.package] version`.
+- the root, `hosts/default`, and `extensions/editor-host` packages all use
+  `version.workspace = true`.
+- `crates/gpui-dotnet/Cargo.lock` is generated; refresh it with Cargo after every bump.
+
+`README.md` carries no version literals: the NuGet badge tracks the latest release and the
+install snippet restores it without `--version`. `eng/check-version.sh` verifies the props,
+workspace, member inheritance, and lock entries all agree, and fails if a pinned version
+literal is reintroduced into `README.md`. The PowerShell equivalent is
+`eng/check-version.ps1`.
+
+Bump the version with:
 
 ```sh
-git tag v0.1.0-preview.1
-git push origin v0.1.0-preview.1
+./eng/bump-version.sh <version>
 ```
+
+The PowerShell equivalent is `./eng/bump-version.ps1 -Version <version>`. The script
+updates `Directory.Build.props`, the Cargo workspace version, and `Cargo.lock`,
+then runs the consistency check. Verify bindings and tests before
+committing, then tag the release commit as described below.
+
+## NuGet release
+
+The `Release` workflow runs when a version tag is pushed. Tag the version recorded in
+`Directory.Build.props` (with an optional leading `v`) and push it:
+
+```sh
+version=$(sed -n 's/.*<Version>\([^<]*\)<\/Version>.*/\1/p' Directory.Build.props)
+git tag "v$version"
+git push origin "v$version"
+```
+
+The PowerShell equivalent is `$version = ([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version`.
 
 It builds and validates the package family, publishes the validated packages to NuGet.org, and
 then creates the GitHub Release with generated notes and package assets. Package versions

--- a/eng/bump-version.ps1
+++ b/eng/bump-version.ps1
@@ -1,0 +1,53 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $Version
+)
+
+$ErrorActionPreference = 'Stop'
+$root = Split-Path -Parent $PSScriptRoot
+
+if ($Version -notmatch '^\d+\.\d+\.\d+(-[0-9A-Za-z\.\-]+)?(\+[0-9A-Za-z\.\-]+)?$') {
+    throw "Invalid version '$Version'. Expected SemVer (major.minor.patch with optional -prerelease/+build)."
+}
+
+function Read-Text([string] $path) {
+    return [System.IO.File]::ReadAllText($path)
+}
+
+function Write-Text([string] $path, [string] $text) {
+    # Normalize to LF and keep exactly one trailing newline, matching repo convention.
+    $text = $text -replace "`r`n", "`n"
+    $text = $text.TrimEnd("`n") + "`n"
+    [System.IO.File]::WriteAllText($path, $text, [System.Text.UTF8Encoding]::new($false))
+}
+
+$propsPath = Join-Path $root 'Directory.Build.props'
+$props = Read-Text $propsPath
+if ($props -notmatch '<Version>[^<]+</Version>') {
+    throw 'Directory.Build.props does not contain <Version>...</Version>.'
+}
+$props = [regex]::Replace($props, '<Version>[^<]+</Version>', "<Version>$Version</Version>", 1)
+Write-Text $propsPath $props
+
+$cargoPath = Join-Path $root 'crates/gpui-dotnet/Cargo.toml'
+$cargo = Read-Text $cargoPath
+if ($cargo -notmatch '\[workspace\.package\]') {
+    throw 'crates/gpui-dotnet/Cargo.toml does not contain [workspace.package]. Run check-version for details.'
+}
+$cargo = [regex]::Replace(
+    $cargo,
+    '(?m)(^\[workspace\.package\][^\[]*?^version\s*=\s*")[^"]+(")',
+    "`${1}$Version`${2}",
+    1)
+Write-Text $cargoPath $cargo
+
+Write-Host "Updated Directory.Build.props and Cargo workspace version to $Version."
+
+$manifest = Join-Path $root 'crates/gpui-dotnet/Cargo.toml'
+& cargo update --manifest-path $manifest -p gpui-dotnet -p gpui-dotnet-default-host -p gpui-dotnet-editor-host 2>&1 | Write-Host
+if ($LASTEXITCODE -ne 0) {
+    throw "cargo update failed. Refresh Cargo.lock with 'cargo metadata --manifest-path crates/gpui-dotnet/Cargo.toml' and retry."
+}
+
+& (Join-Path $root 'eng/check-version.ps1')
+Write-Host "Bumped to $Version. Verify with 'dotnet run --project tools/Gpui.Bindings.Generator -- verify' and commit the change before tagging."

--- a/eng/bump-version.sh
+++ b/eng/bump-version.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+# Bumps the package version across MSBuild and Cargo sources.
+# POSIX equivalent of eng/bump-version.ps1.
+set -eu
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <version>" >&2
+    exit 2
+fi
+
+version=$1
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.+-]+)?(\+[0-9A-Za-z.+-]+)?$'; then
+    echo "Invalid version '$version'. Expected SemVer (major.minor.patch with optional -prerelease/+build)." >&2
+    exit 2
+fi
+
+props="$root/Directory.Build.props"
+if ! grep -q '<Version>[^<]*</Version>' "$props"; then
+    echo 'Directory.Build.props does not contain <Version>...</Version>.' >&2
+    exit 1
+fi
+sed "s|<Version>[^<]*</Version>|<Version>$version</Version>|" "$props" > "$props.tmp"
+mv "$props.tmp" "$props"
+
+cargo_toml="$root/crates/gpui-dotnet/Cargo.toml"
+if ! grep -q '^\[workspace\.package\]' "$cargo_toml"; then
+    echo 'crates/gpui-dotnet/Cargo.toml does not contain [workspace.package]. Run check-version for details.' >&2
+    exit 1
+fi
+sed "/^\\[workspace\\.package\\]/,/^\\[/ s|^version[[:space:]]*=.*|version = \"$version\"|" "$cargo_toml" > "$cargo_toml.tmp"
+mv "$cargo_toml.tmp" "$cargo_toml"
+
+echo "Updated Directory.Build.props and Cargo workspace version to $version."
+
+cargo update --manifest-path "$root/crates/gpui-dotnet/Cargo.toml" -p gpui-dotnet -p gpui-dotnet-default-host -p gpui-dotnet-editor-host
+
+"$root/eng/check-version.sh"
+echo "Bumped to $version. Verify with 'dotnet run --project tools/Gpui.Bindings.Generator -- verify' and commit the change before tagging."

--- a/eng/check-version.ps1
+++ b/eng/check-version.ps1
@@ -1,0 +1,62 @@
+$ErrorActionPreference = 'Stop'
+$root = Split-Path -Parent $PSScriptRoot
+$failed = $false
+
+function Fail([string] $message) {
+    Write-Host "check-version: $message" -ForegroundColor Red
+    $script:failed = $true
+}
+
+[xml] $props = Get-Content -LiteralPath (Join-Path $root 'Directory.Build.props')
+$version = [string] $props.Project.PropertyGroup.Version
+if ([string]::IsNullOrWhiteSpace($version)) {
+    Fail 'Directory.Build.props does not define /Project/PropertyGroup/Version.'
+    $version = ''
+}
+
+$cargoRoot = Get-Content -LiteralPath (Join-Path $root 'crates/gpui-dotnet/Cargo.toml') -Raw
+$workspaceVersion = ([regex]::Match(
+    $cargoRoot,
+    '(?ms)^\[workspace\.package\].*?^version\s*=\s*"([^"]+)"')).Groups[1].Value
+if ([string]::IsNullOrWhiteSpace($workspaceVersion)) {
+    Fail 'crates/gpui-dotnet/Cargo.toml does not define [workspace.package] version.'
+} elseif ($workspaceVersion -ne $version) {
+    Fail "Cargo workspace version '$workspaceVersion' does not match Directory.Build.props '$version'."
+}
+
+foreach ($member in @('hosts/default', 'extensions/editor-host')) {
+    $memberToml = Get-Content -LiteralPath (Join-Path $root "crates/gpui-dotnet/$member/Cargo.toml") -Raw
+    if ($memberToml -match '(?m)^version\s*=\s*"') {
+        Fail "crates/gpui-dotnet/$member/Cargo.toml sets an explicit version; use 'version.workspace = true'."
+    }
+    if ($memberToml -notmatch '(?m)^version\.workspace\s*=\s*true') {
+        Fail "crates/gpui-dotnet/$member/Cargo.toml does not inherit 'version.workspace = true'."
+    }
+}
+
+if ($cargoRoot -notmatch '(?m)^version\.workspace\s*=\s*true') {
+    Fail "crates/gpui-dotnet/Cargo.toml root package does not inherit 'version.workspace = true'."
+}
+
+$lock = Get-Content -LiteralPath (Join-Path $root 'crates/gpui-dotnet/Cargo.lock') -Raw
+foreach ($name in @('gpui-dotnet', 'gpui-dotnet-default-host', 'gpui-dotnet-editor-host')) {
+    $pattern = "(?ms)\[\[package\]\]\s*name\s*=\s*`"$name`"\s*version\s*=\s*`"([^`"]+)`""
+    $match = [regex]::Match($lock, $pattern)
+    if (-not $match.Success) {
+        Fail "Cargo.lock has no entry for '$name'."
+    } elseif ($match.Groups[1].Value -ne $version) {
+        Fail "Cargo.lock '$name' is '$($match.Groups[1].Value)', expected '$version'. Run eng/bump-version.ps1 or 'cargo update -p $name'."
+    }
+}
+
+$readme = Get-Content -LiteralPath (Join-Path $root 'README.md') -Raw
+if ($readme -match 'dotnet add package GPUI\.NET --version \d' -or
+    $readme -match 'current package line is `[^`]+`') {
+    Fail 'README.md must not pin a version literal; use version-agnostic install text.'
+}
+
+if ($script:failed) {
+    throw 'Version check failed. Directory.Build.props is authoritative; sync with eng/bump-version.ps1 -Version <version>.'
+}
+
+Write-Host "Versions consistent at $version."

--- a/eng/check-version.sh
+++ b/eng/check-version.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+# Verifies the package version is consistent across MSBuild and Cargo sources.
+# POSIX equivalent of eng/check-version.ps1.
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+failed=0
+
+fail() {
+    echo "check-version: $1" >&2
+    failed=1
+}
+
+version=$(sed -n 's/^[[:space:]]*<Version>\([^<]*\)<\/Version>.*/\1/p' "$root/Directory.Build.props" | head -n 1)
+if [ -z "${version:-}" ]; then
+    fail 'Directory.Build.props does not define /Project/PropertyGroup/Version.'
+    version=''
+fi
+
+workspace_version=$(awk '/^\[workspace\.package\]/{flag=1;next} /^\[/{flag=0} flag && /^version[[:space:]]*=/ {line=$0; sub(/^[^"]*"/, "", line); sub(/".*$/, "", line); print line; exit}' "$root/crates/gpui-dotnet/Cargo.toml")
+if [ -z "${workspace_version:-}" ]; then
+    fail 'crates/gpui-dotnet/Cargo.toml does not define [workspace.package] version.'
+elif [ "$workspace_version" != "$version" ]; then
+    fail "Cargo workspace version '$workspace_version' does not match Directory.Build.props '$version'."
+fi
+
+for member in 'hosts/default' 'extensions/editor-host'; do
+    member_toml="$root/crates/gpui-dotnet/$member/Cargo.toml"
+    if grep -q '^version[[:space:]]*=' "$member_toml"; then
+        fail "crates/gpui-dotnet/$member/Cargo.toml sets an explicit version; use 'version.workspace = true'."
+    fi
+    if ! grep -q '^version\.workspace[[:space:]]*=[[:space:]]*true' "$member_toml"; then
+        fail "crates/gpui-dotnet/$member/Cargo.toml does not inherit 'version.workspace = true'."
+    fi
+done
+
+if ! grep -q '^version\.workspace[[:space:]]*=[[:space:]]*true' "$root/crates/gpui-dotnet/Cargo.toml"; then
+    fail "crates/gpui-dotnet/Cargo.toml root package does not inherit 'version.workspace = true'."
+fi
+
+lock="$root/crates/gpui-dotnet/Cargo.lock"
+for name in 'gpui-dotnet' 'gpui-dotnet-default-host' 'gpui-dotnet-editor-host'; do
+    lock_version=$(grep -A2 -F "name = \"$name\"" "$lock" | sed -n 's/^version = "\(.*\)"/\1/p' | head -n 1)
+    if [ -z "${lock_version:-}" ]; then
+        fail "Cargo.lock has no entry for '$name'."
+    elif [ "$lock_version" != "$version" ]; then
+        fail "Cargo.lock '$name' is '$lock_version', expected '$version'. Run eng/bump-version.sh or 'cargo update -p $name'."
+    fi
+done
+
+if grep -qE 'dotnet add package GPUI\.NET --version [0-9]|current package line is `' "$root/README.md"; then
+    fail 'README.md must not pin a version literal; use version-agnostic install text.'
+fi
+
+if [ "$failed" -ne 0 ]; then
+    echo 'Version check failed. Directory.Build.props is authoritative; sync with eng/bump-version.sh <version>.' >&2
+    exit 1
+fi
+
+echo "Versions consistent at $version."


### PR DESCRIPTION
# Version bump to `0.2.0-preview.1`

> See [Versioning](../../docs/PACKAGING.md#versioning).

## Checklist

- [x] Bumped with `./eng/bump-version.sh 0.2.0-preview.1` (`./eng/bump-version.ps1 -Version 0.2.0-preview.1` verified idempotent on Windows).
- [x] `./eng/check-version.sh` and `./eng/check-version.ps1` pass.
- [x] `dotnet run --project tools/Gpui.Bindings.Generator -- verify` passes.
- [x] `cargo test --manifest-path crates/gpui-dotnet/Cargo.toml` passes.
- [x] `dotnet test Gpui.slnx --no-restore` passes.
- [x] No version literals added outside `Directory.Build.props`, the Cargo workspace
      version, and generated `Cargo.lock` (`README.md` and tag/doc examples stay
      version-agnostic).

## After merge

Tag the release commit (the `Release` workflow requires the tag on `main`):

```sh
version=$(sed -n 's/.*<Version>\([^<]*\)<\/Version>.*/\1/p' Directory.Build.props)
git tag "v$version"
git push origin "v$version"