### PR TITLE
Fix: flex overflow, orphan validation error, and narrow-width sample wrapping

### DIFF
--- a/crates/gpui-dotnet/src/materializer.rs
+++ b/crates/gpui-dotnet/src/materializer.rs
@@ -228,9 +228,11 @@ impl ManagedView {
         }
         element = apply_styles(element, node, snapshot);
         if last_op(snapshot, node, OP_FLEX_GROW).is_some() {
-            // A growing flex item must be allowed to shrink below its content's intrinsic height;
-            // otherwise a descendant scroll viewport expands to its full content height.
-            element = element.min_h_0();
+            // A growing flex item must be allowed to shrink below its content's intrinsic
+            // size; otherwise a descendant scroll viewport expands to its full content
+            // height, or a growing row item forces the row wider than its parent when a
+            // long text child reports a wide max-content width.
+            element = element.min_h_0().min_w_0();
         }
         element = apply_window_control_area(element, node, snapshot);
 

--- a/samples/Gpui.Sample/Views/ImageGalleryView.cs
+++ b/samples/Gpui.Sample/Views/ImageGalleryView.cs
@@ -45,10 +45,10 @@ internal sealed partial class ImageGalleryView : View
                     .Gap(Px(10))
                     .ItemsCenter(),
                 vectorChart,
-                ui.HStack(contain, cover, grayscale).Gap(Px(14)).JustifyCenter().Grow()
+                ui.HStack(contain, cover, grayscale).Gap(Px(14)).JustifyCenter().Wrap(FlexWrap.Wrap).Grow()
             )
             .Gap(Px(14))
-            .Grow();
+            .Grow().OverflowHidden();
     }
 
     private static Element ImageCard(

--- a/samples/Gpui.Sample/Views/RouteHeaderView.cs
+++ b/samples/Gpui.Sample/Views/RouteHeaderView.cs
@@ -10,8 +10,10 @@ internal sealed partial class RouteHeaderView : View<RouteHeaderProps>
                     .FontSize(Px(ui.Theme.Typography.Heading))
                     .TextColor(ui.Theme.Colors.Text),
                 ui.Text(Props.Detail)
+                    .Width(Percent(100))
                     .FontSize(Px(ui.Theme.Typography.Detail))
                     .TextColor(ui.Theme.Colors.TextMuted)
             )
-            .Gap(Px(3));
+            .Gap(Px(3))
+            .MinWidth(Px(100));
 }

--- a/src/Gpui/Rendering/ManagedValidator.cs
+++ b/src/Gpui/Rendering/ManagedValidator.cs
@@ -440,6 +440,23 @@ internal static unsafe class ManagedValidator
                     }
                 }
             }
+
+            // Edge validation above marks every attached child with Flags bit 0. Any
+            // non-root node left unmarked was declared but never attached to the tree,
+            // which native validation would only report as an opaque status code.
+            for (var nodeIndex = 0; nodeIndex < arena->NodeLength; nodeIndex++)
+            {
+                if (
+                    (uint)nodeIndex != root.Node
+                    && (arena->Nodes[nodeIndex].Flags & 1) == 0
+                )
+                {
+                    var component = (ComponentId)arena->Nodes[nodeIndex].Component;
+                    throw new InvalidOperationException(
+                        $"Node {nodeIndex} ({component}) was declared but never attached to the render tree."
+                    );
+                }
+            }
         }
         finally
         {

--- a/tests/Gpui.Tests/SemanticRenderTests.cs
+++ b/tests/Gpui.Tests/SemanticRenderTests.cs
@@ -1521,6 +1521,13 @@ public sealed class SemanticRenderTests
     }
 
     [Fact]
+    public void DetachedElementsAreRejectedWithAnActionableMessage()
+    {
+        var error = Assert.Throws<InvalidOperationException>(ValidateDetachedElement);
+        Assert.Contains("never attached to the render tree", error.Message);
+    }
+
+    [Fact]
     public void DockControllerValidatesArguments()
     {
         var view = new ProbeView();
@@ -1815,6 +1822,14 @@ public sealed class SemanticRenderTests
         var ui = arena.BeginRender();
         var tabs = ui.DockTabs(panels: ui.DockPanel("orphan", "Orphan", ui.Div()));
         arena.Validate(tabs);
+    }
+
+    private static void ValidateDetachedElement()
+    {
+        using var arena = new RenderArenaOwner();
+        var ui = arena.BeginRender();
+        _ = ui.Text("detached");
+        arena.Validate(ui.Div());
     }
 
     private static void RenderInvalidCircle()


### PR DESCRIPTION
## Summary
- Growing flex items now get `min_w_0` alongside `min_h_0` in the native materializer, so a `Grow` row item with a wide text descendant no longer forces the row past the window (`crates/gpui-dotnet/src/materializer.rs`).
- Managed validation now rejects elements that were declared but never attached to the render tree with an actionable message (`Node N (Component) was declared but never attached to the render tree.`) instead of surfacing later as opaque native status `-13`. All render paths (root, child fragments, list batches) already flow through `ManagedValidator`.
- Sample narrow-width fixes: image cards wrap (`ImageGalleryView`), route header detail wraps (`RouteHeaderView`).

## Verification
- `cargo fmt --check` clean
- `cargo test`: 112 passed
- `dotnet test Gpui.slnx`: 112 passed (incl. new `DetachedElementsAreRejectedWithAnActionableMessage`)
- `dotnet build samples/Gpui.Sample`: clean, `git diff --check` clean