### PR TITLE
Use fixed image height until upstream aspect fill is fixed

### DIFF
--- a/samples/Gpui.Sample/Views/ImageGalleryView.cs
+++ b/samples/Gpui.Sample/Views/ImageGalleryView.cs
@@ -79,7 +79,10 @@ internal sealed partial class ImageGalleryView : View
             .Fit(fit)
             .Grayscale(grayscale)
             .Width(Percent(100))
-            .AspectRatio(4f / 3f)
+            // Fixed height instead of AspectRatio: GPUI fills the Auto axis of a
+            // percent-width image from intrinsic size on load, discarding the ratio
+            // (zed-industries/zed#63747).
+            .Height(Px(180))
             .Radius(Px(12))
             .Background(theme.Colors.ElementActive);
 


### PR DESCRIPTION
## Summary
Reverts the gallery card image from `AspectRatio(4f / 3f)` to fixed `Height(Px(180))`, with a comment citing the upstream issue.

GPUI's `Img::request_layout` backfills the `Auto` axis from intrinsic size whenever the definite axis isn't absolute, so a percent-width image discards an explicit aspect ratio on load and the row jumps to native height (tracked in zed-industries/zed#63747). Fixed height restores stable rows; revert this commit once upstream resolves it.

## Verification
- Sample builds, `git diff --check` clean
- Sample-only change, no framework impact